### PR TITLE
[Fixed]デフォルトで helper と assets ファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Achieve
         controller_specs: true,
         request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
+#デフォルトでhelperとassetsファイルが生成されないようにする
+      g.assets     false
+      g.helper     false
     end
   end
 end


### PR DESCRIPTION
#1 
config/application.rbに  g.assets false,  g.helper falseを追記